### PR TITLE
change author to authors in Forc.toml

### DIFF
--- a/contracts/Forc.toml
+++ b/contracts/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "devel"
+authors = ["devel"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "swayswap"


### PR DESCRIPTION
Updating 'Forc.toml' to use `authors` instead of `author`. This enables compatibility with the change being made in this PR https://github.com/FuelLabs/sway/pull/822