### PR TITLE
feat: deploy client app to gh-pages

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,19 @@
+name: GitHub Pages
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./client

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -4,16 +4,39 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: ./client
+
+    strategy:
+      matrix:
+        node-version: [16.x]
+
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'yarn'
+          cache-dependency-path: client/yarn.lock
+
+      - name: yarn ci and build
+        env:
+          CI: false
+          PUBLIC_URL: "/swayswap-demo"
+        run: |
+          yarn install --frozen-lockfile
+          yarn build
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./client
+          publish_dir: ./client/build

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -6,6 +6,9 @@ on:
       - master
   workflow_dispatch:
 
+env:
+  NODE_VERSION: '16'
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -14,23 +17,19 @@ jobs:
       run:
         working-directory: ./client
 
-    strategy:
-      matrix:
-        node-version: [16.x]
-
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ env.NODE_VERSION }}
           cache: 'yarn'
           cache-dependency-path: client/yarn.lock
 
       - name: yarn ci and build
         env:
           CI: false
-          PUBLIC_URL: "/swayswap-demo"
+          PUBLIC_URL: "/${{ github.event.repository.name }}"
         run: |
           yarn install --frozen-lockfile
           yarn build

--- a/client/package.json
+++ b/client/package.json
@@ -26,6 +26,8 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
+    "postbuild": "yarn create404",
+    "create404": "cp ./build/index.html ./build/404.html",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -6,9 +6,11 @@ import reportWebVitals from "./reportWebVitals";
 import { BrowserRouter } from "react-router-dom";
 import { WalletProvider } from "src/context/WalletContext";
 
+const { PUBLIC_URL } = process.env;
+
 ReactDOM.render(
   <React.StrictMode>
-    <BrowserRouter>
+    <BrowserRouter basename={PUBLIC_URL}>
       <WalletProvider>
         <App />
       </WalletProvider>


### PR DESCRIPTION
## Summary

- Add GitHub action to build source code from client folder and commit to `gh-pages` branch.
- 🚨 Github doesn't support SPA, but it's possible to achieve functionality by adding a `404.html` file, an exact copy from the `index.html`. The only issue with the solution is returned status code instead of being `200` is `404`.

closes: #16 