### PR TITLE
Use new storage syntax and remove unnecessary arguments

### DIFF
--- a/client/src/pages/MintToken.tsx
+++ b/client/src/pages/MintToken.tsx
@@ -35,10 +35,7 @@ export function MintToken() {
 
     try {
       setMinting(true);
-      // TODO: remove second parameter from `mint_coins`.
-      // This is a workaround to a temp problem on the compiler
-      // https://github.com/FuelLabs/swayswap-demo/issues/39
-      await contract.functions.mint_coins(parseUnits(".5", 9), 1);
+      await contract.functions.mint_coins(parseUnits(".5", 9));
       
       // TODO: Improve feedback for the user
       // Navigate to assets page to show new cons

--- a/client/src/types/contracts/TokenContractAbi.d.ts
+++ b/client/src/types/contracts/TokenContractAbi.d.ts
@@ -14,8 +14,8 @@ import type {
 
 interface TokenContractAbiInterface extends Interface {
   functions: {
-    "mint_coins(u64,u32)": FunctionFragment;
-    "burn_coins(u64,u32)": FunctionFragment;
+    "mint_coins(u64)": FunctionFragment;
+    "burn_coins(u64)": FunctionFragment;
     "force_transfer_coins(u64,struct ContractId,struct ContractId)": FunctionFragment;
     "transfer_coins_to_output(u64,struct ContractId,struct Address)": FunctionFragment;
     "get_balance(struct ContractId,struct ContractId)": FunctionFragment;
@@ -23,11 +23,11 @@ interface TokenContractAbiInterface extends Interface {
 
   encodeFunctionData(
     functionFragment: "mint_coins",
-    values: [BigNumberish, BigNumberish]
+    values: [BigNumberish]
   ): string;
   encodeFunctionData(
     functionFragment: "burn_coins",
-    values: [BigNumberish, BigNumberish]
+    values: [BigNumberish]
   ): string;
   encodeFunctionData(
     functionFragment: "force_transfer_coins",
@@ -69,25 +69,21 @@ export class TokenContractAbi extends Contract {
   functions: {
     mint_coins(
       mint_amount: BigNumberish,
-      a: BigNumberish,
       overrides?: Overrides & { from?: string | Promise<string> }
     ): Promise<any>;
 
-    "mint_coins(u64,u32)"(
+    "mint_coins(u64)"(
       mint_amount: BigNumberish,
-      a: BigNumberish,
       overrides?: Overrides & { from?: string | Promise<string> }
     ): Promise<any>;
 
     burn_coins(
       burn_amount: BigNumberish,
-      a: BigNumberish,
       overrides?: Overrides & { from?: string | Promise<string> }
     ): Promise<any>;
 
-    "burn_coins(u64,u32)"(
+    "burn_coins(u64)"(
       burn_amount: BigNumberish,
-      a: BigNumberish,
       overrides?: Overrides & { from?: string | Promise<string> }
     ): Promise<any>;
 
@@ -134,25 +130,21 @@ export class TokenContractAbi extends Contract {
 
   mint_coins(
     mint_amount: BigNumberish,
-    a: BigNumberish,
     overrides?: Overrides & { from?: string | Promise<string> }
   ): Promise<any>;
 
-  "mint_coins(u64,u32)"(
+  "mint_coins(u64)"(
     mint_amount: BigNumberish,
-    a: BigNumberish,
     overrides?: Overrides & { from?: string | Promise<string> }
   ): Promise<any>;
 
   burn_coins(
     burn_amount: BigNumberish,
-    a: BigNumberish,
     overrides?: Overrides & { from?: string | Promise<string> }
   ): Promise<any>;
 
-  "burn_coins(u64,u32)"(
+  "burn_coins(u64)"(
     burn_amount: BigNumberish,
-    a: BigNumberish,
     overrides?: Overrides & { from?: string | Promise<string> }
   ): Promise<any>;
 

--- a/client/src/types/contracts/factories/TokenContractAbi__factory.ts
+++ b/client/src/types/contracts/factories/TokenContractAbi__factory.ts
@@ -17,11 +17,6 @@ const _abi = [
         type: "u64",
         components: null,
       },
-      {
-        name: "a",
-        type: "u32",
-        components: null,
-      },
     ],
     name: "mint_coins",
     outputs: [
@@ -38,11 +33,6 @@ const _abi = [
       {
         name: "burn_amount",
         type: "u64",
-        components: null,
-      },
-      {
-        name: "a",
-        type: "u32",
         components: null,
       },
     ],

--- a/contracts/swayswap_contract/Forc.lock
+++ b/contracts/swayswap_contract/Forc.lock
@@ -4,21 +4,16 @@ dependencies = []
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/FuelLabs/sway?branch=master#6f3439a6431037feee369d584240e3d19b235f41'
-dependencies = ['core']
-
-[[package]]
-name = 'std'
-source = 'git+https://github.com/fuellabs/sway?tag=v0.10.1#5c85d2b712975669d238233297443557969dec43'
+source = 'git+https://github.com/fuellabs/sway?tag=v0.10.3#e7676db6f4ebc7a3885f87514d16a703a99410d7'
 dependencies = ['core']
 
 [[package]]
 name = 'swayswap_abi'
-dependencies = ['std git+https://github.com/FuelLabs/sway?branch=master#6f3439a6431037feee369d584240e3d19b235f41']
+dependencies = ['std git+https://github.com/fuellabs/sway?tag=v0.10.3#e7676db6f4ebc7a3885f87514d16a703a99410d7']
 
 [[package]]
 name = 'swayswap_contract'
 dependencies = [
-    'std git+https://github.com/fuellabs/sway?tag=v0.10.1#5c85d2b712975669d238233297443557969dec43',
+    'std git+https://github.com/fuellabs/sway?tag=v0.10.3#e7676db6f4ebc7a3885f87514d16a703a99410d7',
     'swayswap_abi',
 ]

--- a/contracts/swayswap_contract/tests/harness.rs
+++ b/contracts/swayswap_contract/tests/harness.rs
@@ -74,7 +74,7 @@ async fn swayswap() {
     let token_instance = TestToken::new(token_contract_id.to_string(), provider, wallet.clone());
 
     // Mint some alt tokens
-    token_instance.mint_coins(10000, 1).call().await.unwrap();
+    token_instance.mint_coins(10000).call().await.unwrap();
 
     // Check the balance of the contract of its own asset
     let target = testtoken_mod::ContractId {

--- a/contracts/token_abi/src/main.sw
+++ b/contracts/token_abi/src/main.sw
@@ -3,8 +3,8 @@ library token_abi;
 use std::{address::Address, contract_id::ContractId, token::*};
 
 abi Token {
-    fn mint_coins(mint_amount: u64, a: u32);
-    fn burn_coins(burn_amount: u64, a: u32);
+    fn mint_coins(mint_amount: u64);
+    fn burn_coins(burn_amount: u64);
     fn force_transfer_coins(coins: u64, asset_id: ContractId, target: ContractId);
     fn transfer_coins_to_output(coins: u64, asset_id: ContractId, recipient: Address);
     fn get_balance(target: ContractId, asset_id: ContractId) -> u64;

--- a/contracts/token_contract/Forc.lock
+++ b/contracts/token_contract/Forc.lock
@@ -4,21 +4,16 @@ dependencies = []
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/FuelLabs/sway?branch=master#6f3439a6431037feee369d584240e3d19b235f41'
-dependencies = ['core']
-
-[[package]]
-name = 'std'
-source = 'git+https://github.com/fuellabs/sway?tag=v0.10.1#5c85d2b712975669d238233297443557969dec43'
+source = 'git+https://github.com/fuellabs/sway?tag=v0.10.3#e7676db6f4ebc7a3885f87514d16a703a99410d7'
 dependencies = ['core']
 
 [[package]]
 name = 'token_abi'
-dependencies = ['std git+https://github.com/FuelLabs/sway?branch=master#6f3439a6431037feee369d584240e3d19b235f41']
+dependencies = ['std git+https://github.com/fuellabs/sway?tag=v0.10.3#e7676db6f4ebc7a3885f87514d16a703a99410d7']
 
 [[package]]
 name = 'token_contract'
 dependencies = [
-    'std git+https://github.com/fuellabs/sway?tag=v0.10.1#5c85d2b712975669d238233297443557969dec43',
+    'std git+https://github.com/fuellabs/sway?tag=v0.10.3#e7676db6f4ebc7a3885f87514d16a703a99410d7',
     'token_abi',
 ]

--- a/contracts/token_contract/src/main.sw
+++ b/contracts/token_contract/src/main.sw
@@ -4,11 +4,11 @@ use std::{address::Address, context::balance_of, contract_id::ContractId, token:
 use token_abi::Token;
 
 impl Token for Contract {
-    fn mint_coins(mint_amount: u64, a: u32) {
+    fn mint_coins(mint_amount: u64) {
         mint(mint_amount);
     }
 
-    fn burn_coins(burn_amount: u64, a: u32) {
+    fn burn_coins(burn_amount: u64) {
         burn(burn_amount);
     }
 


### PR DESCRIPTION
With `forc 0.10.3`, single argument contract methods work as expected. We can now use the new storage syntax as well, at least for the total LP token supply.